### PR TITLE
lint: fix warnings of linter #14

### DIFF
--- a/api/action/html-to-pdf.go
+++ b/api/action/html-to-pdf.go
@@ -6,7 +6,8 @@ import (
 	"github.com/opsway/documents/cmd/document"
 )
 
-func HtmlToPdfGet(w http.ResponseWriter, r *http.Request) {
+// HTMLToPdfGet renders pdf from html
+func HTMLToPdfGet(w http.ResponseWriter, r *http.Request) {
 	content := r.URL.Query().Get("content")
 
 	if content == "" {

--- a/api/action/render-template.go
+++ b/api/action/render-template.go
@@ -8,12 +8,14 @@ import (
 	"github.com/opsway/documents/cmd/template"
 )
 
+// RenderTemplateRequest refers request of rendering pdf
 type RenderTemplateRequest struct {
 	TemplateName    string            `json:"templateName"`
 	Data            template.Context  `json:"data"`
 	DocumentOptions document.Document `json:"documentOptions"`
 }
 
+// RenderTemplate render pdf by template from request
 func RenderTemplate(w http.ResponseWriter, r *http.Request) {
 	request := RenderTemplateRequest{}
 	err := json.NewDecoder(r.Body).Decode(&request)

--- a/api/config.go
+++ b/api/config.go
@@ -1,5 +1,6 @@
 package api
 
+// Config is preference of api
 type Config struct {
 	Address       string
 	TemplatesPath string

--- a/api/middleware/logger.go
+++ b/api/middleware/logger.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// HTTP middleware that logging,
+// Logger is HTTP  middleware that logging,
 func Logger(inner http.Handler, name string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()

--- a/api/routers.go
+++ b/api/routers.go
@@ -1,4 +1,4 @@
-// Documents generation API
+// Package api refers to pdf converter API
 //
 //     BasePath: /
 //     Version: 1.0
@@ -24,6 +24,7 @@ import (
 	"github.com/opsway/documents/cmd/template"
 )
 
+// Route is a structure of entry point
 type Route struct {
 	Name        string
 	Method      string
@@ -31,8 +32,10 @@ type Route struct {
 	HandlerFunc http.HandlerFunc
 }
 
+// Routes is array of entrypoints this api
 type Routes []Route
 
+// NewHandler generates http handler to serve a File
 func NewHandler(config Config) http.Handler {
 	_ = template.BuildTemplates(config.TemplatesPath) // TODO parse error
 
@@ -42,6 +45,7 @@ func NewHandler(config Config) http.Handler {
 	return handlers.RecoveryHandler()(router)
 }
 
+// NewRouter handles function of this api
 func NewRouter() *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
 	for _, route := range routes {
@@ -61,7 +65,7 @@ func NewRouter() *mux.Router {
 
 var routes = Routes{
 
-	// swagger:operation GET /html-to-pdf HtmlToPdfGet
+	// swagger:operation GET /html-to-pdf HTMLToPdfGet
 	//
 	// Render URL to PDF
 	//
@@ -80,10 +84,10 @@ var routes = Routes{
 	//   '422':
 	//     description: Validation error
 	Route{
-		"HtmlToPdfGet",
+		"HTMLToPdfGet",
 		strings.ToUpper("Get"),
 		"/html-to-pdf",
-		action.HtmlToPdfGet,
+		action.HTMLToPdfGet,
 	},
 
 	// swagger:operation POST /render-template RenderTemplatePost

--- a/api/server.go
+++ b/api/server.go
@@ -6,6 +6,7 @@ import (
 	"time"
 )
 
+// Server provides new api from config
 func Server(config Config) {
 	log.Printf("Starting the service...")
 

--- a/cmd/document/document.go
+++ b/cmd/document/document.go
@@ -1,5 +1,6 @@
 package document
 
+// Document refers the information of page viewing
 type Document struct {
 	Orientation  string `json:"orientation"`
 	PageSize     string `json:"pageSize"`

--- a/cmd/document/pdf.go
+++ b/cmd/document/pdf.go
@@ -11,11 +11,13 @@ import (
 	"github.com/opsway/documents/util"
 )
 
+//Pdf is structure of pdf generator
 type Pdf struct {
 	generator *generator.PDFGenerator
 	option    Document
 }
 
+// SetOptions settle margin and page size of pdf
 func (pdf *Pdf) SetOptions(option Document) {
 	pdf.generator.Orientation.Set(option.Orientation)
 	pdf.generator.PageSize.Set(option.PageSize)
@@ -25,27 +27,32 @@ func (pdf *Pdf) SetOptions(option Document) {
 	pdf.generator.MarginRight.Set(option.MarginRight)
 }
 
-func (pdf *Pdf) AddPageFromUrl(url string) {
+// AddPageFromURL generates pdf pages from url
+func (pdf *Pdf) AddPageFromURL(url string) {
 	pdf.generator.AddPage(generator.NewPage(url))
 }
 
+// AddPageFromString generates pdf pages including string
 func (pdf *Pdf) AddPageFromString(content string) {
 	pdf.AddPage(strings.NewReader(content))
 }
 
+// AddPage generates pdf pages inputed content
 func (pdf *Pdf) AddPage(input io.Reader) {
 	pdf.generator.AddPage(generator.NewPageReader(input))
 }
 
+// Render creates pdf to writer
 func (pdf *Pdf) Render(writer io.Writer) error {
 	pdf.generator.SetOutput(writer)
 
 	return pdf.generator.Create()
 }
 
+// RenderByContent creates pdf from content
 func (pdf *Pdf) RenderByContent(writer io.Writer, content string) error {
-	if util.IsValidUrl(content) {
-		pdf.AddPageFromUrl(content)
+	if util.IsValidURL(content) {
+		pdf.AddPageFromURL(content)
 	} else {
 		pdf.AddPageFromString(content)
 	}
@@ -53,6 +60,7 @@ func (pdf *Pdf) RenderByContent(writer io.Writer, content string) error {
 	return pdf.Render(writer)
 }
 
+// RenderByTemplate creates pdf from template and data
 func (pdf *Pdf) RenderByTemplate(writer io.Writer, templateName string, data template.Context) error {
 	tmpl, err := template.GetTemplate(templateName)
 
@@ -76,6 +84,7 @@ func (pdf *Pdf) RenderByTemplate(writer io.Writer, templateName string, data tem
 	return pdf.Render(writer)
 }
 
+// NewPdf return pdf generator
 func NewPdf() (*Pdf, error) {
 	pdfg, err := generator.NewPDFGenerator()
 

--- a/cmd/template/template.go
+++ b/cmd/template/template.go
@@ -12,8 +12,10 @@ import (
 
 var templates map[string]*Template
 
+// Context refers various context of templates
 type Context map[string]interface{}
 
+// Template refers the pongo2 template data
 type Template struct {
 	path    string
 	name    string
@@ -21,6 +23,7 @@ type Template struct {
 	Context map[string]interface{}
 }
 
+// Render outputs the templates to writer
 func (tmpl *Template) Render(context Context, writer io.Writer) error {
 	return tmpl.index.ExecuteWriter(pongo2.Context(context), writer)
 }
@@ -41,6 +44,7 @@ func (tmpl *Template) load() error {
 	return nil
 }
 
+// NewTemplate generates template specified file path and name
 func NewTemplate(path string, name string) (*Template, error) {
 	path = filepath.Join(path, name, "index.html")
 	tmpl := &Template{path: path, name: name}
@@ -53,6 +57,7 @@ func NewTemplate(path string, name string) (*Template, error) {
 	return tmpl, nil
 }
 
+// GetTemplate returns template specified by name
 func GetTemplate(name string) (*Template, error) {
 	tmpl, exists := templates[name]
 	if !exists {
@@ -63,6 +68,7 @@ func GetTemplate(name string) (*Template, error) {
 	return tmpl, nil
 }
 
+// BuildTemplates makes templates which is specified by file path
 func BuildTemplates(path string) error {
 	files, err := ioutil.ReadDir(path)
 

--- a/util/http.go
+++ b/util/http.go
@@ -7,7 +7,8 @@ import (
 	"net/url"
 )
 
-func GetUrl(url string) (io.Reader, error) {
+// GetURL returns response body of url
+func GetURL(url string) (io.Reader, error) {
 	response, err := http.Get(url)
 
 	if err != nil {
@@ -21,7 +22,8 @@ func GetUrl(url string) (io.Reader, error) {
 	return response.Body, nil
 }
 
-func IsValidUrl(content string) bool {
+// IsValidURL indicate validate raw url
+func IsValidURL(content string) bool {
 	_, err := url.ParseRequestURI(content)
 
 	if err != nil {

--- a/util/http_test.go
+++ b/util/http_test.go
@@ -1,34 +1,35 @@
 package util
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestUtil(t *testing.T) {
 
-	Convey("GetUrl", t, func() {
+	Convey("GetURL", t, func() {
 		Convey("empty", func() {
-			_, err := GetUrl("")
+			_, err := GetURL("")
 			So(err, ShouldNotBeNil)
 		})
 		Convey("error status", func() {
-			_, err := GetUrl("https://github.com/opsway/documents/foo")
+			_, err := GetURL("https://github.com/opsway/documents/foo")
 			So(err, ShouldNotBeNil)
 		})
 		Convey("content", func() {
-			actual, err := GetUrl("https://github.com/opsway")
+			actual, err := GetURL("https://github.com/opsway")
 			So(err, ShouldBeNil)
 			So(actual, ShouldNotBeNil)
 		})
 	})
 
-	Convey("IsValidUrl", t, func() {
+	Convey("IsValidURL", t, func() {
 		Convey("empty", func() {
-			So(IsValidUrl(""), ShouldBeFalse)
+			So(IsValidURL(""), ShouldBeFalse)
 		})
 		Convey("valid", func() {
-			So(IsValidUrl("https://opsway.com"), ShouldBeTrue)
+			So(IsValidURL("https://opsway.com"), ShouldBeTrue)
 		})
 	})
 }

--- a/util/os.go
+++ b/util/os.go
@@ -2,6 +2,7 @@ package util
 
 import "os"
 
+// Getenv returns the environment variables specified key in this machine
 func Getenv(key string, fallback string) string {
 	value := os.Getenv(key)
 	if len(value) == 0 {
@@ -11,6 +12,7 @@ func Getenv(key string, fallback string) string {
 	return value
 }
 
+// IsValidDir indicates existence of directory path in this machine
 func IsValidDir(path string) bool {
 	fi, err := os.Stat(path)
 	if os.IsNotExist(err) {


### PR DESCRIPTION
A similar PR may already be submitted!
**Summary**
I fixed golint warnings #14 


**Test plan**
before:
```
$ golint ./...
api/config.go:3:6: exported type Config should have comment or be unexported
api/routers.go:1:1: package comment should be of the form "Package api ..."
api/routers.go:27:6: exported type Route should have comment or be unexported
api/routers.go:34:6: exported type Routes should have comment or be unexported
api/routers.go:36:1: exported function NewHandler should have comment or be unexported
api/routers.go:45:1: exported function NewRouter should have comment or be unexported
api/server.go:9:1: exported function Server should have comment or be unexported
api/action/html-to-pdf.go:9:1: exported function HtmlToPdfGet should have comment or be unexported
api/action/html-to-pdf.go:9:6: func HtmlToPdfGet should be HTMLToPdfGet
api/action/render-template.go:11:6: exported type RenderTemplateRequest should have comment or be unexported
api/action/render-template.go:17:1: exported function RenderTemplate should have comment or be unexported
api/middleware/logger.go:9:1: comment on exported function Logger should be of the form "Logger ..."
cmd/document/document.go:3:6: exported type Document should have comment or be unexported
cmd/document/pdf.go:14:6: exported type Pdf should have comment or be unexported
cmd/document/pdf.go:19:1: exported method Pdf.SetOptions should have comment or be unexported
cmd/document/pdf.go:28:1: exported method Pdf.AddPageFromUrl should have comment or be unexported
cmd/document/pdf.go:28:17: method AddPageFromUrl should be AddPageFromURL
cmd/document/pdf.go:32:1: exported method Pdf.AddPageFromString should have comment or be unexported
cmd/document/pdf.go:36:1: exported method Pdf.AddPage should have comment or be unexported
cmd/document/pdf.go:40:1: exported method Pdf.Render should have comment or be unexported
cmd/document/pdf.go:46:1: exported method Pdf.RenderByContent should have comment or be unexported
cmd/document/pdf.go:56:1: exported method Pdf.RenderByTemplate should have comment or be unexported
cmd/document/pdf.go:79:1: exported function NewPdf should have comment or be unexported
cmd/template/template.go:15:6: exported type Context should have comment or be unexported
cmd/template/template.go:17:6: exported type Template should have comment or be unexported
cmd/template/template.go:24:1: exported method Template.Render should have comment or be unexported
cmd/template/template.go:44:1: exported function NewTemplate should have comment or be unexported
cmd/template/template.go:56:1: exported function GetTemplate should have comment or be unexported
cmd/template/template.go:66:1: exported function BuildTemplates should have comment or be unexported
util/http.go:10:1: exported function GetUrl should have comment or be unexported
util/http.go:10:6: func GetUrl should be GetURL
util/http.go:24:1: exported function IsValidUrl should have comment or be unexported
util/http.go:24:6: func IsValidUrl should be IsValidURL
util/os.go:5:1: exported function Getenv should have comment or be unexported
util/os.go:14:1: exported function IsValidDir should have comment or be unexported
$
```

after:
```
$ golint ./...
$
```

**Closing issues**
Fixes #14 